### PR TITLE
Changes the implementation of accumulated predictions (prevents underflow in some cases)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+**.DS_Store
 # C extensions
 *.so
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 defusedxml>=0.7.1
 einops>=0.5.0
 h5py==3.9.0
-huggingface_hub
+huggingface_hub<=0.20.3
 hydra-core>1.3,<=1.3.2
 nibabel==5.1.0
 numba

--- a/tests/collections/multitask/rs/models/test_mtlrs.py
+++ b/tests/collections/multitask/rs/models/test_mtlrs.py
@@ -222,6 +222,76 @@ from tests.collections.reconstruction.mri_data.conftest import create_input
                 "max_steps": -1,
             },
         ),
+        (
+            [1, 3, 32, 16, 2],
+            {
+                "use_reconstruction_module": True,
+                "task_adaption_type": "multi_task_learning",
+                "joint_reconstruction_segmentation_module_cascades": 5,
+                "reconstruction_module_recurrent_layer": "IndRNN",
+                "reconstruction_module_conv_filters": [64, 64, 2],
+                "reconstruction_module_conv_kernels": [5, 3, 3],
+                "reconstruction_module_conv_dilations": [1, 2, 1],
+                "reconstruction_module_conv_bias": [True, True, False],
+                "reconstruction_module_recurrent_filters": [64, 64, 0],
+                "reconstruction_module_recurrent_kernels": [1, 1, 0],
+                "reconstruction_module_recurrent_dilations": [1, 1, 0],
+                "reconstruction_module_recurrent_bias": [True, True, False],
+                "reconstruction_module_depth": 2,
+                "reconstruction_module_conv_dim": 2,
+                "reconstruction_module_time_steps": 8,
+                "reconstruction_module_num_cascades": 5,
+                "reconstruction_module_dimensionality": 2,
+                "reconstruction_module_accumulate_predictions": True,
+                "reconstruction_module_no_dc": True,
+                "reconstruction_module_keep_prediction": True,
+                "reconstruction_loss": {"l1": 1.0},
+                "segmentation_module": "ConvLayer",
+                "segmentation_module_input_channels": 1,
+                "segmentation_module_output_channels": 4,
+                "segmentation_module_channels": 64,
+                "segmentation_module_pooling_layers": 4,
+                "segmentation_module_dropout": 0.0,
+                "segmentation_module_accumulate_predictions": True,
+                "segmentation_loss": {"dice": 1.0},
+                "dice_loss_include_background": False,
+                "dice_loss_to_onehot_y": False,
+                "dice_loss_sigmoid": True,
+                "dice_loss_softmax": False,
+                "dice_loss_other_act": None,
+                "dice_loss_squared_pred": False,
+                "dice_loss_jaccard": False,
+                "dice_loss_reduction": "mean",
+                "dice_loss_smooth_nr": 1,
+                "dice_loss_smooth_dr": 1,
+                "dice_loss_batch": True,
+                "consecutive_slices": 1,
+                "coil_combination_method": "SENSE",
+                "magnitude_input": True,
+                "use_sens_net": False,
+                "fft_centered": False,
+                "fft_normalization": "backward",
+                "spatial_dims": [-2, -1],
+                "coil_dim": 1,
+                "dimensionality": 2,
+            },
+            [0.08],
+            [4],
+            2,
+            4,
+            {
+                "strategy": "ddp",
+                "accelerator": "cpu",
+                "num_nodes": 1,
+                "max_epochs": 20,
+                "precision": 32,
+                "enable_checkpointing": False,
+                "logger": False,
+                "log_every_n_steps": 50,
+                "check_val_every_n_epoch": -1,
+                "max_steps": -1,
+            },
+        ),
     ],
 )
 def test_mtlmrirs(shape, cfg, center_fractions, accelerations, dimensionality, segmentation_classes, trainer):
@@ -281,20 +351,25 @@ def test_mtlmrirs(shape, cfg, center_fractions, accelerations, dimensionality, s
             output.sum(coil_dim),
         )
 
-    if cfg.get("accumulate_predictions"):
-        try:
-            pred_reconstruction = next(pred_reconstruction)
-        except StopIteration:
-            pass
+    if cfg.get("reconstruction_module_accumulate_predictions"):
+        if len(pred_reconstruction) != cfg.get("joint_reconstruction_segmentation_module_cascades"):
+            raise AssertionError("Number of predictions are not equal to the number of cascades")
+        if cfg.get("reconstruction_module_keep_prediction"):
+            if len(pred_reconstruction[0]) != cfg.get("reconstruction_module_num_cascades"):
+                raise AssertionError("Number of predictions are not equal to the number of cascades")
+        if cfg.get("reconstruction_module_keep_prediction"):
+            if len(pred_reconstruction[0][0]) != cfg.get("reconstruction_module_time_steps"):
+                raise AssertionError("Number of predictions are not equal to the number of intermediate predictions")
 
-    if isinstance(pred_reconstruction, list):
+    if cfg.get("segmentation_module_accumulate_predictions"):
+        if len(pred_segmentation) != cfg.get("joint_reconstruction_segmentation_module_cascades"):
+            raise AssertionError(f"Number of segmentations are not equal to the number of cascades")
+
+    while isinstance(pred_reconstruction, list):
         pred_reconstruction = pred_reconstruction[-1]
 
-    if isinstance(pred_reconstruction, list):
-        pred_reconstruction = pred_reconstruction[-1]
-
-    if isinstance(pred_reconstruction, list):
-        pred_reconstruction = pred_reconstruction[-1]
+    while isinstance(pred_segmentation, list):
+        pred_segmentation = pred_segmentation[-1]
 
     if dimensionality == 3 or consecutive_slices > 1:
         x = x.reshape([x.shape[0] * x.shape[1], x.shape[2], x.shape[3], x.shape[4], x.shape[5]])


### PR DESCRIPTION
# What does this PR do?

Fixes issues related to underflow by changing the accumulation approach. Also added an option to perform accumulate predictions on segmentation. 

**Collection**: Multi-task

# Changelog

**Initial implementation**
```python
loss = sum(x * w for x, w in zip(rs_cascades_loss, rs_cascades_weights)) / len(prediction)
```
**Advised implementation**
```python
loss = sum(x * w for x, w in zip(rs_cascades_loss, rs_cascades_weights)) / sum(rs_cascades_weights)
```

[Weighted average](https://abdulkaderhelwan.medium.com/understanding-weighted-average-f379b078b3e6)

Since the individual weights are =< 1 dividing the weighted sum by the number of predictions results in a diminishing of the loss. Especially when performing the average weighted 3 times in the MTLRS.

# Usage
* You can potentially add a usage example below



# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/wdika/atommic/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:
- [x] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/wdika/atommic/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
